### PR TITLE
Upgrade mcode-action from v1 to v4

### DIFF
--- a/.github/workflows/mayhem.yml
+++ b/.github/workflows/mayhem.yml
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Start analysis for ${{ matrix.mayhemfile }}
-        uses: ForAllSecure/mcode-action@v1
+        uses: ForAllSecure/mcode-action@v4
         with:
           mayhem-token: ${{ secrets.MAYHEM_TOKEN }}
           args: --image ${{ needs.build.outputs.image }} --file ${{ matrix.mayhemfile }} --duration 300


### PR DESCRIPTION
The mcode-action@v1 has been deprecated. Updating it to the latest stable version.